### PR TITLE
Revert "Build(deps-dev): Bump eazy-logger from 4.0.1 to 4.1.0 in /bp-web-client/angular-app-legacy"

### DIFF
--- a/bp-web-client/angular-app-legacy/package-lock.json
+++ b/bp-web-client/angular-app-legacy/package-lock.json
@@ -7659,9 +7659,9 @@
       }
     },
     "node_modules/eazy-logger": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.1.0.tgz",
-      "integrity": "sha512-+mn7lRm+Zf1UT/YaH8WXtpU6PIV2iOjzP6jgKoiaq/VNrjYKp+OHZGe2znaLgDeFkw8cL9ffuaUm+nNnzcYyGw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.0.1.tgz",
+      "integrity": "sha512-2GSFtnnC6U4IEKhEI7+PvdxrmjJ04mdsj3wHZTFiw0tUtG4HCWzTr13ZYTk8XOGnA1xQMaDljoBOYlk3D/MMSw==",
       "dev": true,
       "dependencies": {
         "chalk": "4.1.2"
@@ -23228,9 +23228,9 @@
       }
     },
     "eazy-logger": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.1.0.tgz",
-      "integrity": "sha512-+mn7lRm+Zf1UT/YaH8WXtpU6PIV2iOjzP6jgKoiaq/VNrjYKp+OHZGe2znaLgDeFkw8cL9ffuaUm+nNnzcYyGw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.0.1.tgz",
+      "integrity": "sha512-2GSFtnnC6U4IEKhEI7+PvdxrmjJ04mdsj3wHZTFiw0tUtG4HCWzTr13ZYTk8XOGnA1xQMaDljoBOYlk3D/MMSw==",
       "dev": true,
       "requires": {
         "chalk": "4.1.2"


### PR DESCRIPTION
Reverts byte-pushers/bp-web#415

Travis CI Build Failed.
```
$ rvm use $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl -v 2.0.5.1
ERROR:  Error installing dpl:
	The last version of json_pure (~> 2) to support your Ruby & RubyGems was 2.7.6. Try installing it with `gem install json_pure -v 2.7.6` and then running the current command again
	json_pure requires Ruby version >= 2.7. The current ruby version is 2.4.5.335.
Successfully installed mime-0.4.4
The command "rvm use $(travis_internal_ruby) --fuzzy do ruby -S gem install dpl -v 2.0.5.1" failed and exited with 1 during .
Your build has been stopped.
```